### PR TITLE
Helpful note for those using Docker Toolbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Run the setup:
 bash setup.sh
 ```
 
-
 Go to http://localhost:1337 in your browser, then see Usage below.
 
 ## Path 2: Robust but not easy

--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ cp docker-compose.env.example docker-compose.env
 $EDITOR docker-compose.env
 ```
 
+Note: If you are using Docker Toolbox you will also need to expose the port 1337 via the virtualbox port forwarding feature.
+
 Run the setup:
 
 ```
 bash setup.sh
 ```
+
 
 Go to http://localhost:1337 in your browser, then see Usage below.
 


### PR DESCRIPTION
When following these instructions I would see the message "Waiting for grafana to start..." after look at the code I discovered it was because I needed to enable port forwarding for Docker Toolbox.

I saw another note in the same doc for Docker toolbox, so I figured it was relevant.