### PR TITLE
added support for shard in API call

### DIFF
--- a/docker-compose.env.example
+++ b/docker-compose.env.example
@@ -1,3 +1,4 @@
 SCREEPS_USERNAME=bkconrad
 SCREEPS_EMAIL=notreally@myemail.com
 SCREEPS_PASSWORD=definitelynotmypassword
+SCREEPS_SHARD=shard3

--- a/src/ScreepsStatsd.coffee
+++ b/src/ScreepsStatsd.coffee
@@ -68,6 +68,7 @@ class ScreepsStatsd
         "X-Username": token
       qs:
         path: 'stats'
+        shard: process.env.SCREEPS_SHARD
     rp(options).then (x) =>
       # yeah... dunno why
       token = x.headers['x-token']


### PR DESCRIPTION
Not sure if people still use this one rather than screepspl.us hosted dashboards. I like the custom agent option and prefer to self-host, however.

The `https://screeps.com/api/user/memory` call was getting a response 'invalid shard'. Looks like API was updated and shard value has to be passed on. There are several other things which may be updated, but I made minimal changes just to fix it.